### PR TITLE
feat: add phaser rendering skeleton

### DIFF
--- a/src/game/rendering/CardSprite.ts
+++ b/src/game/rendering/CardSprite.ts
@@ -1,0 +1,39 @@
+import Phaser from 'phaser';
+import { Card } from '../Game';
+import { tweenTo } from './TweenHelper';
+
+/**
+ * Visual representation of a card.
+ * Mirrors Unity's card prefab using a Phaser container.
+ */
+export class CardSprite extends Phaser.GameObjects.Container {
+    public readonly card: Card;
+    private sprite: Phaser.GameObjects.Sprite;
+
+    constructor(scene: Phaser.Scene, card: Card, texture: string, frame?: string | number) {
+        super(scene);
+        this.card = card;
+        this.sprite = scene.add.sprite(0, 0, texture, frame);
+        this.add(this.sprite);
+        scene.add.existing(this);
+    }
+
+    /**
+     * Tween the card to a new position using easing similar to DOTween.
+     */
+    moveTo(x: number, y: number): Promise<void> {
+        return tweenTo(this.scene, this, { x, y, duration: 300 });
+    }
+
+    /**
+     * Flip animation to reveal or hide the card's face.
+     */
+    flip(): Promise<void> {
+        return tweenTo(this.scene, this.sprite, {
+            scaleX: 0,
+            duration: 100,
+            yoyo: true,
+            ease: Phaser.Math.Easing.Sine.InOut,
+        });
+    }
+}

--- a/src/game/rendering/PileGroup.ts
+++ b/src/game/rendering/PileGroup.ts
@@ -1,0 +1,32 @@
+import Phaser from 'phaser';
+import { CardSprite } from './CardSprite';
+
+/**
+ * Represents a pile of cards. Mirrors Unity's hierarchy by grouping card sprites.
+ */
+export class PileGroup extends Phaser.GameObjects.Group {
+    constructor(scene: Phaser.Scene, children?: CardSprite[]) {
+        super(scene);
+        if (children) {
+            children.forEach((c) => this.add(c));
+        }
+    }
+
+    /**
+     * Adds a card to the pile and triggers a layout animation.
+     */
+    addCard(card: CardSprite): void {
+        this.add(card);
+        this.layout();
+    }
+
+    /**
+     * Layout cards with a small offset, animating using tweens.
+     */
+    layout(): void {
+        this.getChildren().forEach((child, index) => {
+            const card = child as CardSprite;
+            card.moveTo(card.x, index * 30);
+        });
+    }
+}

--- a/src/game/rendering/SolitaireScene.ts
+++ b/src/game/rendering/SolitaireScene.ts
@@ -1,0 +1,44 @@
+import Phaser from 'phaser';
+import { Card } from '../Game';
+import { CardSprite } from './CardSprite';
+import { PileGroup } from './PileGroup';
+
+/**
+ * Main scene responsible for rendering piles and cards using Phaser groups.
+ */
+export class SolitaireScene extends Phaser.Scene {
+    pileStock!: PileGroup;
+    pileWaste!: PileGroup;
+    pileFoundations!: PileGroup[];
+    pileTableaus!: PileGroup[];
+
+    constructor() {
+        super({ key: 'SolitaireScene' });
+    }
+
+    create(): void {
+        this.pileStock = new PileGroup(this);
+        this.pileWaste = new PileGroup(this);
+
+        this.pileFoundations = [];
+        for (let i = 0; i < 4; i++) {
+            const foundation = new PileGroup(this);
+            this.pileFoundations.push(foundation);
+        }
+
+        this.pileTableaus = [];
+        for (let i = 0; i < 7; i++) {
+            const tableau = new PileGroup(this);
+            this.pileTableaus.push(tableau);
+        }
+    }
+
+    /**
+     * Creates a card sprite and adds it to a pile.
+     */
+    addCardToPile(card: Card, pile: PileGroup, texture: string): CardSprite {
+        const sprite = new CardSprite(this, card, texture);
+        pile.addCard(sprite);
+        return sprite;
+    }
+}

--- a/src/game/rendering/TweenHelper.ts
+++ b/src/game/rendering/TweenHelper.ts
@@ -1,0 +1,41 @@
+import Phaser from 'phaser';
+import { Tween, Easing, update } from '@tweenjs/tween.js';
+
+let ticking = false;
+
+/**
+ * Creates a tween using tween.js to mimic DOTween easing.
+ */
+export function tweenTo(
+    scene: Phaser.Scene,
+    target: any,
+    { x, y, duration = 300, ease = Easing.Quadratic.Out, yoyo = false }: {
+        x?: number;
+        y?: number;
+        duration?: number;
+        ease?: (amount: number) => number;
+        yoyo?: boolean;
+    }
+): Promise<void> {
+    return new Promise((resolve) => {
+        const to: any = {};
+        if (typeof x === 'number') to.x = x;
+        if (typeof y === 'number') to.y = y;
+
+        const tween = new Tween(target)
+            .to(to, duration)
+            .easing(ease)
+            .onComplete(() => resolve())
+            .start();
+
+        if (yoyo) {
+            tween.yoyo(true);
+            tween.repeat(1);
+        }
+
+        if (!ticking) {
+            scene.events.on('update', () => update());
+            ticking = true;
+        }
+    });
+}

--- a/src/game/rendering/index.ts
+++ b/src/game/rendering/index.ts
@@ -1,0 +1,4 @@
+export * from './CardSprite';
+export * from './PileGroup';
+export * from './SolitaireScene';
+export * from './TweenHelper';


### PR DESCRIPTION
## Summary
- add Phaser 3 scene with groups mirroring Unity piles
- create card and pile components with tween-based animations
- integrate tween.js easing helper to approximate DOTween

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run build` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aba2afcbf483328d6373fa757c9d5c