### PR TITLE
feat: add leaderboard api and hook

### DIFF
--- a/pages/api/leaderboard.ts
+++ b/pages/api/leaderboard.ts
@@ -1,0 +1,54 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { kv } from '@vercel/kv';
+
+export interface LeaderboardItem {
+  points: number;
+  date: string;
+}
+
+const STORAGE_KEY = 'leaderboard';
+const MAX_COUNT = 9;
+
+function compareItems(a: LeaderboardItem, b: LeaderboardItem) {
+  const pointCompare = a.points - b.points;
+  if (pointCompare !== 0) return pointCompare;
+  return a.date.localeCompare(b.date);
+}
+
+function addItem(list: LeaderboardItem[], item: LeaderboardItem): LeaderboardItem[] {
+  const updated = [...list, item];
+  updated.sort((a, b) => compareItems(b, a));
+  return updated.slice(0, MAX_COUNT);
+}
+
+async function loadLeaderboard(): Promise<LeaderboardItem[]> {
+  const data = await kv.get<LeaderboardItem[]>(STORAGE_KEY);
+  return Array.isArray(data) ? data : [];
+}
+
+async function saveLeaderboard(items: LeaderboardItem[]): Promise<void> {
+  await kv.set(STORAGE_KEY, items);
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method === 'POST') {
+    const item = req.body as LeaderboardItem;
+    const items = await loadLeaderboard();
+    const updated = addItem(items, item);
+    await saveLeaderboard(updated);
+    res.status(200).json(updated);
+    return;
+  }
+
+  if (req.method === 'GET') {
+    const items = await loadLeaderboard();
+    res.status(200).json(items);
+    return;
+  }
+
+  res.setHeader('Allow', ['GET', 'POST']);
+  res.status(405).end('Method Not Allowed');
+}

--- a/src/hooks/useLeaderboard.ts
+++ b/src/hooks/useLeaderboard.ts
@@ -1,0 +1,45 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export interface LeaderboardItem {
+  points: number;
+  date: string;
+}
+
+export function useLeaderboard() {
+  const [items, setItems] = useState<LeaderboardItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchLeaderboard = useCallback(async () => {
+    try {
+      setLoading(true);
+      const res = await fetch('/api/leaderboard');
+      const data = await res.json();
+      setItems(Array.isArray(data) ? data : []);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const addScore = useCallback(async (item: LeaderboardItem) => {
+    try {
+      const res = await fetch('/api/leaderboard', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(item),
+      });
+      const data = await res.json();
+      setItems(Array.isArray(data) ? data : []);
+    } catch (err) {
+      setError(err as Error);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchLeaderboard();
+  }, [fetchLeaderboard]);
+
+  return { items, loading, error, refresh: fetchLeaderboard, addScore };
+}


### PR DESCRIPTION
## Summary
- add Next.js API route for leaderboard persistence using Vercel KV
- create React hook to manage leaderboard state and updates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aba3957bb0833288ec7ef23b94c514