### PR TITLE
feat: add responsive components

### DIFF
--- a/src/components/ControlButtons.tsx
+++ b/src/components/ControlButtons.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Game } from '../game/Game';
+import styles from './GameBoard.module.css';
+
+interface Props {
+  game: Game & {
+    undo?: () => void;
+    hint?: () => void;
+  };
+  onShowLeaderboard?: () => void;
+}
+
+export default function ControlButtons({ game, onShowLeaderboard }: Props) {
+  return (
+    <div className={styles.controls}>
+      <button onClick={() => game.drawCard()}>Draw</button>
+      <button onClick={() => game.undo?.()}>Undo</button>
+      <button onClick={() => game.hint?.()}>Hint</button>
+      {onShowLeaderboard && (
+        <button onClick={onShowLeaderboard}>Leaderboard</button>
+      )}
+    </div>
+  );
+}

--- a/src/components/GameBoard.module.css
+++ b/src/components/GameBoard.module.css
@@ -1,0 +1,40 @@
+.gameBoard {
+  width: 100vw;
+  height: 100vh;
+  display: grid;
+}
+
+.board {
+  background: #006400;
+}
+
+.sidebar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.controls {
+  display: flex;
+  gap: 0.5rem;
+}
+
+@media (orientation: landscape) {
+  .gameBoard {
+    grid-template-columns: 3fr 1fr;
+    grid-template-rows: 1fr;
+  }
+  .controls {
+    flex-direction: column;
+  }
+}
+
+@media (orientation: portrait) {
+  .gameBoard {
+    grid-template-columns: 1fr;
+    grid-template-rows: 3fr 1fr;
+  }
+  .controls {
+    flex-direction: row;
+  }
+}

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -1,0 +1,27 @@
+import React, { useRef, useState } from 'react';
+import { Game } from '../game/Game';
+import ControlButtons from './ControlButtons';
+import Popup from './Popup';
+import Leaderboard from './Leaderboard';
+import styles from './GameBoard.module.css';
+
+interface Props {
+  game: Game;
+}
+
+export default function GameBoard({ game }: Props) {
+  const boardRef = useRef<HTMLDivElement>(null);
+  const [showLeaderboard, setShowLeaderboard] = useState(false);
+
+  return (
+    <div className={styles.gameBoard}>
+      <div ref={boardRef} className={styles.board} />
+      <div className={styles.sidebar}>
+        <ControlButtons game={game} onShowLeaderboard={() => setShowLeaderboard(true)} />
+      </div>
+      <Popup open={showLeaderboard} onClose={() => setShowLeaderboard(false)}>
+        <Leaderboard />
+      </Popup>
+    </div>
+  );
+}

--- a/src/components/Leaderboard.module.css
+++ b/src/components/Leaderboard.module.css
@@ -1,0 +1,9 @@
+.leaderboard {
+  text-align: center;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useLeaderboard } from '../hooks/useLeaderboard';
+import styles from './Leaderboard.module.css';
+
+export default function Leaderboard() {
+  const { items, loading, error } = useLeaderboard();
+
+  if (loading) {
+    return <div className={styles.leaderboard}>Loading...</div>;
+  }
+  if (error) {
+    return <div className={styles.leaderboard}>Error loading leaderboard</div>;
+  }
+
+  return (
+    <div className={styles.leaderboard}>
+      <h2>Leaderboard</h2>
+      <ol className={styles.list}>
+        {items.map((item, idx) => (
+          <li key={idx}>
+            {item.points} - {item.date}
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/src/components/Popup.module.css
+++ b/src/components/Popup.module.css
@@ -1,0 +1,19 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.content {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 4px;
+  max-width: 90%;
+}

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -1,0 +1,21 @@
+import React, { ReactNode } from 'react';
+import styles from './Popup.module.css';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export default function Popup({ open, onClose, children }: Props) {
+  if (!open) return null;
+
+  return (
+    <div className={styles.overlay} onClick={onClose}>
+      <div className={styles.content} onClick={(e) => e.stopPropagation()}>
+        {children}
+        <button onClick={onClose}>Close</button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- build responsive GameBoard layout with controls and leaderboard popup
- wire control buttons to game commands for draw, undo and hint actions
- implement reusable popup and leaderboard components

## Testing
- `npm test` *(fails: No such file or directory)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aba45c6a2083328aacb6a2bdae97a9