### PR TITLE
Initialize Next.js project with TypeScript

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+
+export {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "solitaire",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "solitaire",
+      "version": "1.0.0",
+      "dependencies": {
+        "next": "^14.0.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.3.0",
+        "@types/react": "^18.2.0",
+        "@types/node": "^20.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "solitaire",
+  "version": "1.0.0",
+  "description": "![Solitaire Menu](https://github.com/gubicsz/Solitaire/blob/master/Content/Solitaire1.gif) ![Solitaire Gameplay](https://github.com/gubicsz/Solitaire/blob/master/Content/Solitaire2.gif)",
+  "main": "index.js",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "next": "^14.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.0",
+    "@types/react": "^18.2.0",
+    "@types/node": "^20.0.0"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up Node project with Next.js, React, and TypeScript dependencies
- add Next.js dev/build/start scripts and TypeScript config
- include placeholder lockfile and `next-env.d.ts`

## Testing
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aba79f544c83329de3932a82e0f599